### PR TITLE
Updated Link: Projects using etcd

### DIFF
--- a/etcd/getting-started-with-etcd.md
+++ b/etcd/getting-started-with-etcd.md
@@ -227,7 +227,7 @@ $ curl http://127.0.0.1:2379/v2/keys/foo
 #### More information
 <a class="btn btn-default" href="https://coreos.com/etcd">etcd Overview</a>
 <a class="btn btn-default" href="https://github.com/coreos/etcd">Full etcd API Docs</a>
-<a class="btn btn-default" href="https://github.com/coreos/etcd/blob/master/Documentation/libraries-and-tools.md">Projects using etcd</a>
+<a class="btn btn-default" href="https://github.com/coreos/etcd/blob/master/Documentation/v2/libraries-and-tools.md">Projects using etcd</a>
 
 
 [cl-configs]: ../os/provisioning.md


### PR DESCRIPTION
Link updated to - https://github.com/coreos/etcd/blob/master/Documentation/v2/libraries-and-tools.md
Old link (broken) - https://github.com/coreos/etcd/blob/master/Documentation/libraries-and-tools.md